### PR TITLE
feat: support env variable substitution

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,10 +7,23 @@ interface BuildStatusColors {
   error: string;
 }
 
-const siteId = vscode.workspace.getConfiguration('netlify').get('site_id') as string;
-const apiToken = vscode.workspace.getConfiguration('netlify').get('api_token') as string;
+function substituteEnvVariables(input: string): string {
+  let configString = JSON.stringify(input);
+
+  if (configString && /\${env:[^}]+}/.test(configString)) {
+    const { groups } = configString.match(/\${env:(?<name>[^}]+)\}/) as RegExpMatchArray;
+
+    if (groups?.name && process.env[groups.name]) {
+      configString = configString.replace(/(\${env:[^}]+})/g, process.env[groups.name] as string);
+    }
+  }
+  return configString
+}
+
+const siteId = substituteEnvVariables(vscode.workspace.getConfiguration('netlify').get('site_id') as string);
+const apiToken = substituteEnvVariables(vscode.workspace.getConfiguration('netlify').get('api_token') as string);
 const setInterval = vscode.workspace.getConfiguration('netlify').get('set_interval') as number;
-const buildHook = vscode.workspace.getConfiguration('netlify').get('build_hook') as string;
+const buildHook = substituteEnvVariables(vscode.workspace.getConfiguration('netlify').get('build_hook') as string);
 const buildStatusColors = vscode.workspace.getConfiguration('netlify').get('build_status_colors') as BuildStatusColors;
 
 export {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,9 +7,7 @@ interface BuildStatusColors {
   error: string;
 }
 
-function substituteEnvVariables(input: string): string {
-  let configString = JSON.stringify(input);
-
+function substituteEnvVariables(configString: string): string {
   if (configString && /\${env:[^}]+}/.test(configString)) {
     const { groups } = configString.match(/\${env:(?<name>[^}]+)\}/) as RegExpMatchArray;
 


### PR DESCRIPTION
### Motivation
We can't store sensitive information like Netlify API keys in `.vscode/settings.json` for security reasons.

We would like to use environment variables instead.

### Changes
Handles env variable substitution for some contributed config variables.

_Note: this only handles the `${env:MY_VAR}` case, and does not try to handle every type of substitution._

e.g.
```json
{
  "netlify.api_token": "${env:MY_NETLIFY_PAT}",
  "netlify.build_hook": "${env:MY_NETLIFY_BUILD_HOOK}",
  "netlify.site_id": "${env:MY_NETLIFY_SITE_ID}"
}
```

### Alternatives
If upstream VSCode presents a way to handle variables substitution for contributed config, this might not be needed.
See: https://github.com/Microsoft/vscode/issues/46471

We could take a more drastic approach and encrypt the `settings.json` using something like  [git secret](https://git-secret.io/).

Other attempts at patching this:
https://github.com/idleberg/node-vscode-get-config
https://github.com/DominicVonk/vscode-variables